### PR TITLE
Use user-provided private SSH key instead of self-generating one

### DIFF
--- a/install/installer.tf
+++ b/install/installer.tf
@@ -99,7 +99,7 @@ platform:
   aws:
     region: ${var.aws_region}
 pullSecret: '${file(var.openshift_pull_secret)}'
-sshKey: '${tls_private_key.installkey.public_key_openssh}'
+sshKey: '${data.tls_public_key.installkey.public_key_openssh}'
 %{if var.airgapped["enabled"]}imageContentSources:
 - mirrors:
   - ${var.airgapped["repository"]}

--- a/install/output.tf
+++ b/install/output.tf
@@ -15,10 +15,10 @@ output "worker_ign_64" {
 }
 
 output "private_ssh_key" {
-    value =  tls_private_key.installkey.private_key_pem
+    value =  data.tls_public_key.installkey.private_key_pem
 }
 
 output "public_ssh_key" {
-    value =  tls_private_key.installkey.public_key_openssh
+    value =  data.tls_public_key.installkey.public_key_openssh
 }
 

--- a/install/ssh_key.tf
+++ b/install/ssh_key.tf
@@ -1,4 +1,3 @@
-resource "tls_private_key" "installkey" {
-  algorithm   = "RSA"
-  rsa_bits = 4096
+data "tls_public_key" "installkey" {
+  private_key_pem = "${file(var.private_ssh_key_file)}"
 }

--- a/install/variables.tf
+++ b/install/variables.tf
@@ -55,14 +55,11 @@ variable "aws_worker_root_volume_size" {
 
 variable "aws_worker_root_volume_iops" {
   type = string
-
   description = <<EOF
 The amount of provisioned IOPS for the root block device of worker nodes.
 Ignored if the volume type is not io1.
 EOF
-
 }
-
 
 variable "master_count" {
   type        = number
@@ -79,6 +76,12 @@ variable "openshift_installer_url" {
   type        = string
   description = "The URL to download OpenShift installer."
   default     = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest"
+}
+
+variable "private_ssh_key_file" {
+  type        = string
+  description = "path to an unencrypted PEM-encoded private SSH key"
+  default     = "~/.ssh/id_rsa"
 }
 
 variable "aws_access_key_id" {

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,7 @@ module "installer" {
   aws_region = var.aws_region
   aws_access_key_id = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key
+  private_ssh_key_file = var.private_ssh_key_file
   vpc_cidr_block = var.machine_cidr
   master_count = length(var.aws_azs)
   openshift_pull_secret = var.openshift_pull_secret

--- a/variables-aws.tf
+++ b/variables-aws.tf
@@ -121,6 +121,12 @@ variable "aws_private_subnets" {
   description = "(optional) Existing private subnets into which the cluster should be installed."
 }
 
+variable "private_ssh_key_file" {
+  type        = string
+  description = "path to an unencrypted PEM-encoded private SSH key"
+  default     = "~/.ssh/id_rsa"
+}
+
 variable "aws_publish_strategy" {
   type = string
   description = "The cluster publishing strategy, either Internal or External"


### PR DESCRIPTION
This answer to Issue #36 (here) keeps the Terraform tfstate file from needing to store an unencrypted copy of a generated private key by exchanging a resource that allocates a private key with a data source that accepts an existing key as bound input.

Adds one new input variable, private_ssh_key_file, which defaults to ~/.ssh/id_rsa.